### PR TITLE
Update WebagilHeroiconsExtension.php

### DIFF
--- a/src/DependencyInjection/WebagilHeroiconsExtension.php
+++ b/src/DependencyInjection/WebagilHeroiconsExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WebagilHeroiconsExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
         $loader->load('config.php');


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Webagil\Heroicons\DependencyInjection\WebagilHeroiconsExtension" now to avoid errors or add an explicit @return annotation to suppress this message.